### PR TITLE
Fix typo

### DIFF
--- a/lib/hamt.js
+++ b/lib/hamt.js
@@ -743,7 +743,7 @@ const visit = (map, f) =>
     new MapIterator(lazyVisit(map._root, f));
 
 /**
-    Get a Javascsript iterator of `map`.
+    Get a Javascript iterator of `map`.
 
     Iterates over `[key, value]` arrays.
 */


### PR DESCRIPTION
“Javascsript” → “Javascript”