### PR TITLE
README code example typo patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ h.get('key') === 'value'
 for (let [key, value] of h)
     console.log(key, value);
 
-Array.from(h.values()) === [{ prop: 1 }, 'value'], null];
+Array.from(h.values()) === [{ prop: 1 }, 'value', null];
 
 // The data structure is fully immutable
 var h2 = h.delete('key');


### PR DESCRIPTION
Was just reading up on the data strucuture and noticed a typo. This PR removes a single character from the README. Apologies if I've missed any PR/Contrib guidelines, I just decided to quickly patch the typo via Github's quick access VSCode IDE. LMK if you would like me to re-submit this PR with updated formatting conforming to any guidelines that you may have. Cheers.